### PR TITLE
Продолжение PR #24

### DIFF
--- a/assets/snippets/DocLister/core/controller/sg_site_content.php
+++ b/assets/snippets/DocLister/core/controller/sg_site_content.php
@@ -20,25 +20,28 @@ class sg_site_contentDocLister extends site_contentDocLister
     public function getDocs($tvlist = '')
     {
         $docs = parent::getDocs($tvlist);
-        $table = $this->modx->getFullTableName('sg_images');
+		
+        $table = $this->getTable('sg_images');
         $rid = $this->modx->db->escape(implode(',',array_keys($docs)));
         $sgOrderBy = $this->modx->db->escape($this->getCFGDef('sgOrderBy','sg_index ASC'));
+		
         $sgDisplay = $this->getCFGDef('sgDisplay','all');
         $sgAddWhereList = $this->modx->db->escape($this->getCFGDef('sgAddWhereList',''));
+		
         if (!empty($sgAddWhereList)) $sgAddWhereList = ' AND ('.$sgAddWhereList.')';
         if (!empty($rid) && ($sgDisplay == 'all' || is_numeric($sgDisplay))) {
             switch ($sgDisplay) {
                 case 'all':
-                    $sql = "SELECT * FROM $table WHERE `sg_rid` IN ($rid) $sgAddWhereList ORDER BY $sgOrderBy";
+                    $sql = "SELECT * FROM {$table} WHERE `sg_rid` IN ({$rid}) {$sgAddWhereList} ORDER BY {$sgOrderBy}";
                     break;
                 case '1':
-                    $sql = "SELECT * FROM (SELECT * FROM $table WHERE `sg_rid` IN ($rid) $sgAddWhereList ORDER BY $sgOrderBy) sg GROUP BY $sg_rid";
+                    $sql = "SELECT * FROM (SELECT * FROM {$table} WHERE `sg_rid` IN ({$rid}) {$sgAddWhereList} ORDER BY {$sgOrderBy}) sg GROUP BY {$sg_rid}";
                     break;
                 default:
-                    $sql = "SELECT * FROM (SELECT *, @rn := IF(@prev = `sg_rid`, @rn + 1, 1) AS rn, @prev := `sg_rid` FROM $table JOIN (SELECT @prev := NULL, @rn := 0) AS vars WHERE `sg_rid` IN ($rid) ORDER BY sg_rid, $sgOrderBy) AS sg WHERE rn <= $sgDisplay";
+                    $sql = "SELECT * FROM (SELECT *, @rn := IF(@prev = `sg_rid`, @rn + 1, 1) AS rn, @prev := `sg_rid` FROM {$table} JOIN (SELECT @prev := NULL, @rn := 0) AS vars WHERE `sg_rid` IN ({$rid}) ORDER BY sg_rid, {$sgOrderBy}) AS sg WHERE rn <= {$sgDisplay}";
                     break;
             }
-            $images = $this->modx->db->query($sql);
+            $images = $this->dbQuery($sql);
             while ($image = $this->modx->db->getRow($images)) {
                 $_rid = $image['sg_rid'];
                 $docs[$_rid]['images'][] = $image;

--- a/install/assets/snippets/sgLister.tpl
+++ b/install/assets/snippets/sgLister.tpl
@@ -30,11 +30,14 @@ if(!class_exists("DLsgLister", false)){
 	class DLsgLister{
 		public static function prepare(array $data = array(), DocumentParser $modx, $_DL, prepare_DL_Extender $_extDocLister){
 			$imageField = $_DL->getCfgDef('imageField');
-			$data['thumb.'.$imageField] = $modx->runSnippet('phpthumb', array(
-				'input' => $data[$imageField],
-				'options' => $_DL->getCfgDef('thumbOptions')
-			));
-			
+			$thumbOptions = $_DL->getCfgDef('thumbOptions');
+			$thumbSnippet = $_DL->getCfgDef('thumbSnippet');
+			if(!empty($thumbOptions) && !empty($thumbSnippet)){
+				$data['thumb.'.$imageField] = $modx->runSnippet($thumbSnippet, array(
+					'input' => $data[$imageField],
+					'options' => $thumbOptions
+				));
+			}
 			$titleField = $_DL->getCfgDef('titleField');
 			$data['e.'.$titleField] = htmlentities($data[$titleField], ENT_COMPAT, 'UTF-8', false);
 			


### PR DESCRIPTION
Подмена thumb сниппета + замена modx->db->query() на dbQuery от DocLister'a.
Можно не создавать еще 1 prepare сниппет. Достаточно создать кастомный thumb который указать в параметре thumbSnippet.
Допустим:

```
&thumbSnippet=`sgThumb` &options=`120x120`
```

И сам сниппет sgThumb

``` php
$file = end(explode('/',$input)); 
return str_replace($file, $options.'/'.$file, $input);
```

В итоге никакого лишнего кода. Можно пользоваться как плагином для сжатия, так и стандартным phpthumb. А параметрами разруливать на уровне обычного вызова.
