### PR TITLE
fix window load event

### DIFF
--- a/assets/plugins/simplegallery/tpl/simplegallery.tpl
+++ b/assets/plugins/simplegallery/tpl/simplegallery.tpl
@@ -42,7 +42,7 @@ var sgConfig = {
     clientResize:[+clientResize+]
 };
 (function($) {
-	$(window).load(function(){
+	$(window).on('load',function(){
     	if ($('#sg-tab')) {
     		$('#sg-tab.selected').trigger('click');    
 		}


### PR DESCRIPTION
Маленький фикс, чтобы галерея работала с jquery 3.0+ без jquery-migrate. $(window).load() deprecated [proof](https://jquery.com/upgrade-guide/3.0/#breaking-change-load-unload-and-error-removed).
#78