### PR TITLE
Added check whether variable exists to avoid PHP8 error

### DIFF
--- a/assets/snippets/simplegallery/sgLister.php
+++ b/assets/snippets/simplegallery/sgLister.php
@@ -14,7 +14,11 @@
 
 include_once(MODX_BASE_PATH . 'assets/lib/APIHelpers.class.php');
 
-$_prepare = explode(',', $prepare);
+if (isset($prepare)) {
+    $_prepare = explode(',', $prepare);
+} else {
+    $_prepare = array();
+}
 $prepare = array();
 $prepare[] = \APIhelpers::getkey($modx->event->params, 'BeforePrepare', '');
 $prepare = array_merge($prepare, $_prepare);


### PR DESCRIPTION
I added a necessary check to see whether the variable `$prepare` exists. If the variable does not exists, then PHP8 raises Warning, as opposed to Notice in previous versions, see https://www.php.net/manual/en/migration80.incompatible.php